### PR TITLE
Refactor create_image tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,25 @@ The purpose of this role is to:
 * Create any required config to be mounted by the Barbican images for connecting to the HSMs.
 
 We expect some preparatory steps to be completed prior to execution in order for the role to complete successfully:
-* The Proteccio Client ISO file has been obtained from Eviden:
-* The location of the Proteccio Client ISO file should be made available at proteccio_client_src.
-* All of the certificates and keys needed to communicate with the HSM(s) must be copied to the proteccio_crt_src directory.
-  * These include the server certificates, which typically have the format <ip_address>.crt.
-  * These also include the client certificate and key, which typically have the format <client_name>.crt and <client_name>.key.
+* The Proteccio Client ISO file has been obtained from Eviden.
+* The location of the Proteccio Client ISO file should be made available at `proteccio_client_src`.
+* All of the certificates and keys needed to communicate with the HSM(s) must be copied to the `proteccio_crt_src` directory.
+  * These include the server certificates, which typically have the format `<ip_address>.crt`.
+  * These also include the client certificate and key, which typically have the format `<client_name>.crt` and `<client_name>.key`.
   * All these files will ultimately be referenced in your proteccio.rc file.
-* The proteccio.rc is available at proteccio_conf_src.
+* The proteccio.rc is available at `proteccio_conf_src`.
 * The certs and proteccio.rc will be retrieved from the given locations and stored in a secret (proteccio_data_secret).
 * The PIN (password) to log into the HSM will be stored in a secret (login_secret).
 
 A minimal (one that takes the defaults) invocation of this role is shown below.  In this case, the Proteccio Client
-software and required certificates and configuration files are stored locally under /opt/proteccio.
+software and required certificates and configuration files are stored locally under `/opt/proteccio`.
 
     ---
     - hosts: localhost
       vars:
         barbican_dest_image_namespace: "{{ your quay.io account name }}"
-        proteccio_client_src: "file:///opt/proteccio/Proteccio3.06.05.iso"
+        proteccio_client_iso: "Proteccio3.06.05.iso"
+        proteccio_client_src: "file:///opt/proteccio/{{ proteccio_client_iso }}"
         proteccio_password: "{{ PIN to log into proteccio }}"
         kubeconfig_path: "/path/to/.kube/config"
         oc_dir: "/path/to/oc/bin/dir/"
@@ -39,7 +40,8 @@ You can also do the steps separately.
     - hosts: localhost
       vars:
         barbican_dest_image_namespace: "{{ your quay.io account name }}"
-        proteccio_client_src: "file:///opt/proteccio/Proteccio3.06.05.iso"
+        proteccio_client_iso: "Proteccio3.06.05.iso"
+        proteccio_client_src: "file:///opt/proteccio/{{ proteccio_client_iso }}"
        tasks:
        - name: Create new Barbican images with the Proteccio Client
          ansible.builtin.include_role:
@@ -67,16 +69,21 @@ You can also do the steps separately.
 | `working_dir` | string  | `/tmp/hsm-prep-working-dir` | Working directory to store artifacts.                           |
 
 ### Image Generation Variables
-| Variable                        | Type    | Default Value                                | Description                                      |
-| ------------------------------- | ------- | ---------------------------------------------| ------------------------------------------------ |
-| `barbican_src_image_registry`   | string  | `quay.io`                                    | Registry used to pull down the Barbican images   |
-| `barbican_src_image_namespace`  | string  | `podified-antelope-centos9`                  | Registry namespace for the Barbican images       |
-| `barbican_src_image_tag`        | string  | `current-podified`                           | Tag used to identify the source images           |
-| `barbican_dest_image_registry`  | string  | `quay.io`                                    | Registry used to push the modified images        |
-| `barbican_dest_image_namespace` | string  | `podified-antelope-centos9`                  | Registry namespace for the modified images       |
-| `barbican_dest_image_tag`       | string  | `current-podified-proteccio`                 | Tag used to identify the modified images         |
-| `proteccio_client_src`          | string  | `file:///opt/proteccio/Proteccio3.06.05.iso` | Location of the Proteccio Client ISO file        |
-| `image_registry_verify_tls`     | boolean | `true`                                       | Use TLS verification when pushing/pulling images |
+| Variable                          | Type    | Default Value                                | Description                                      |
+| -------------------------------   | ------- | ---------------------------------------------| ------------------------------------------------ |
+| `proteccio_client_iso`            | string  | `Proteccio3.06.05.iso`                       | File name of the Proteccio Client ISO file       |
+| `proteccio_client_src`            | string  | `file:///opt/proteccio/Proteccio3.06.05.iso` | Location of the Proteccio Client ISO file        |
+| `barbican_src_image_registry`     | string  | `quay.io`                                    | Registry used to pull down the Barbican images   |
+| `barbican_src_image_namespace`    | string  | `podified-antelope-centos9`                  | Registry namespace for the Barbican images       |
+| `barbican_src_api_image_name`     | string  | `openstack-barbican-api`                     | Name of the Barbican API image to be pulled      |
+| `barbican_src_worker_image_name`  | string  | `openstack-barbican-worker`                  | Name of the Barbican Worker image to be pulled   |
+| `barbican_src_image_tag`          | string  | `current-podified`                           | Tag used to identify the source images           |
+| `barbican_dest_image_registry`    | string  | `quay.io`                                    | Registry used to push the modified images        |
+| `barbican_dest_image_namespace`   | string  | `podified-antelope-centos9`                  | Registry namespace for the modified images       |
+| `barbican_dest_api_image_name`    | string  | `openstack-barbican-api`                     | Name of the Barbican API image to be pushed      |
+| `barbican_dest_worker_image_name` | string  | `openstack-barbican-worker`                  | Name of the Barbican Worker image to be pushed   |
+| `barbican_dest_image_tag`         | string  | `current-podified-proteccio`                 | Tag used to identify the modified images         |
+| `image_registry_verify_tls`       | boolean | `true`                                       | Use TLS verification when pushing/pulling images |
 
 ### Secret Generation Variables
 | Variable                          | Type   | Default Value                                  | Description                                                                                   |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,8 +21,8 @@ cleanup: false
 working_dir: "/tmp/hsm-prep-working-dir"
 
 ### Proteccio Parameters
-proteccio_client_src: "file:///opt/proteccio/Proteccio3.06.05.iso"
 proteccio_client_iso: "Proteccio3.06.05.iso"
+proteccio_client_src: "file:///opt/proteccio/Proteccio3.06.05.iso"
 proteccio_crt_src: "/opt/proteccio/certs/"
 #proteccio_client_crt_src: "file:///opt/proteccio/client.crt"
 #proteccio_client_key_src: "file:///opt/proteccio/client.key"
@@ -34,13 +34,15 @@ login_secret_field: "PKCS11Pin"
 
 ### Image Details
 image_registry_verify_tls: true
+
 barbican_src_image_registry: "quay.io"
 barbican_src_image_namespace: "podified-antelope-centos9"
+barbican_src_api_image_name: "openstack-barbican-api"
+barbican_src_worker_image_name: "openstack-barbican-worker"
 barbican_src_image_tag: "current-podified"
-barbican_src_api_image: "#/barbican_src_image_registry/#/barbican_src_image_namespace/openstack-barbican-api:#/barbican_src_image_tag"
-barbican_src_worker_image: "#/barbican_src_image_registry/#/barbican_src_image_namespace/openstack-barbican-worker:#/barbican_src_image_tag"
+
 barbican_dest_image_registry: "quay.io"
 barbican_dest_image_namespace: "podified-antelope-centos9"
+barbican_dest_api_image_name: "openstack-barbican-api"
+barbican_dest_worker_image_name: "openstack-barbican-worker"
 barbican_dest_image_tag: "current-podified-proteccio"
-barbican_dest_api_image: "#/barbican_dest_image_registry/#/barbican_dest_image_namespace/openstack-barbican-api:#/barbican_dest_image_tag"
-barbican_dest_worker_image: "#/barbican_dest_image_registry/#/barbican_dest_image_namespace/openstack-barbican-worker:#/barbican_dest_image_tag"

--- a/files/image_add_proteccio_client.sh
+++ b/files/image_add_proteccio_client.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# barbican_add_proteccio_client.sh
+# image_add_proteccio_client.sh
 #
 # This script adds the Linux Minimal Client for Eviden Trustway Proteccio HSM
 # to both the API and Worker images so that the HSM can be used as a PKCS#11
@@ -11,15 +11,21 @@ set -o pipefail
 
 BARBICAN_SRC_IMAGE_REGISTRY=${BARBICAN_SRC_IMAGE_REGISTRY:-"quay.io"}
 BARBICAN_SRC_IMAGE_NAMESPACE=${BARBICAN_SRC_IMAGE_NAMESPACE:-"podified-antelope-centos9"}
+BARBICAN_SRC_API_IMAGE_NAME=${BARBICAN_SRC_API_IMAGE_NAME:-"openstack-barbican-api"}
+BARBICAN_SRC_WORKER_IMAGE_NAME=${BARBICAN_SRC_WORKER_IMAGE_NAME:-"openstack-barbican-worker"}
 BARBICAN_SRC_IMAGE_TAG=${BARBICAN_SRC_IMAGE_TAG:-"current-podified"}
-BARBICAN_SRC_API_IMAGE="$BARBICAN_SRC_IMAGE_REGISTRY/$BARBICAN_SRC_IMAGE_NAMESPACE/openstack-barbican-api:$BARBICAN_SRC_IMAGE_TAG"
-BARBICAN_SRC_WORKER_IMAGE="$BARBICAN_SRC_IMAGE_REGISTRY/$BARBICAN_SRC_IMAGE_NAMESPACE/openstack-barbican-worker:$BARBICAN_SRC_IMAGE_TAG"
+
+BARBICAN_SRC_API_IMAGE_FQIN="$BARBICAN_SRC_IMAGE_REGISTRY/$BARBICAN_SRC_IMAGE_NAMESPACE/$BARBICAN_SRC_API_IMAGE_NAME:$BARBICAN_SRC_IMAGE_TAG"
+BARBICAN_SRC_WORKER_IMAGE_FQIN="$BARBICAN_SRC_IMAGE_REGISTRY/$BARBICAN_SRC_IMAGE_NAMESPACE/$BARBICAN_SRC_WORKER_IMAGE_NAME:$BARBICAN_SRC_IMAGE_TAG"
 
 BARBICAN_DEST_IMAGE_REGISTRY=${BARBICAN_DEST_IMAGE_REGISTRY:-"quay.io"}
-BARBICAN_DEST_IMAGE_NAMESPACE=${BARBICAN_DEST_IMAGE_NAMESPACE:-"rh_ee_mharley"}
-BARBICAN_DEST_IMAGE_TAG=${BARBICAN_DEST_IMAGE_TAG:-"current-podified"}
-BARBICAN_DEST_API_IMAGE="$BARBICAN_DEST_IMAGE_REGISTRY/$BARBICAN_DEST_IMAGE_NAMESPACE/openstack-barbican-api:$BARBICAN_DEST_IMAGE_TAG"
-BARBICAN_DEST_WORKER_IMAGE="$BARBICAN_DEST_IMAGE_REGISTRY/$BARBICAN_DEST_IMAGE_NAMESPACE/openstack-barbican-worker:$BARBICAN_DEST_IMAGE_TAG"
+BARBICAN_DEST_IMAGE_NAMESPACE=${BARBICAN_DEST_IMAGE_NAMESPACE:-"podified-antelope-centos9"}
+BARBICAN_DEST_API_IMAGE_NAME=${BARBICAN_DEST_API_IMAGE_NAME:-"openstack-barbican-api"}
+BARBICAN_DEST_WORKER_IMAGE_NAME=${BARBICAN_DEST_WORKER_IMAGE_NAME:-"openstack-barbican-worker"}
+BARBICAN_DEST_IMAGE_TAG=${BARBICAN_DEST_IMAGE_TAG:-"current-podified-proteccio"}
+
+BARBICAN_DEST_API_IMAGE_FQIN="$BARBICAN_DEST_IMAGE_REGISTRY/$BARBICAN_DEST_IMAGE_NAMESPACE/$BARBICAN_DEST_API_IMAGE_NAME:$BARBICAN_DEST_IMAGE_TAG"
+BARBICAN_DEST_WORKER_IMAGE_FQIN="$BARBICAN_DEST_IMAGE_REGISTRY/$BARBICAN_DEST_IMAGE_NAMESPACE/$BARBICAN_DEST_WORKER_IMAGE_NAME:$BARBICAN_DEST_IMAGE_TAG"
 
 # PROTECCIO_LINUX_CLIENT_DIR - location of the linux client directory
 # in your client media.  This could be a path to a mounted ISO or a path to
@@ -44,6 +50,7 @@ function install_client() {
   buildah add --chown root:root $container $PROTECCIO_LINUX_CLIENT_DIR /tmp/proteccio
   buildah run --user root $container -- cd /tmp/proteccio/Linux
   buildah run --user root $container -- bash -c "cd /tmp/proteccio/Linux; { echo \"e\"; echo \"n\"; echo; } | ./install.sh"
+  buildah run --user root $container -- rm -rf /tmp/proteccio
 
   if [ "$VERIFY_TLS" == "true" ]; then
     buildah commit $container $2
@@ -55,5 +62,5 @@ function install_client() {
   buildah rm $container
 }
 
-install_client $BARBICAN_SRC_API_IMAGE $BARBICAN_DEST_API_IMAGE
-install_client $BARBICAN_SRC_WORKER_IMAGE $BARBICAN_DEST_WORKER_IMAGE
+install_client $BARBICAN_SRC_API_IMAGE_FQIN $BARBICAN_DEST_API_IMAGE_FQIN
+install_client $BARBICAN_SRC_WORKER_IMAGE_FQIN $BARBICAN_DEST_WORKER_IMAGE_FQIN

--- a/tasks/create_image.yml
+++ b/tasks/create_image.yml
@@ -14,6 +14,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Download build tools
+  become: true
+  ansible.builtin.dnf:
+    name:
+      - buildah
+      - podman
+    state: present
+
 - name: Create working directory
   ansible.builtin.file:
     path: "{{ working_dir }}"
@@ -23,54 +31,62 @@
 - name: Get Proteccio client ISO
   ansible.builtin.get_url:
     url: "{{ proteccio_client_src }}"
-    dest: "{{ working_dir }}/"
+    dest: "{{ working_dir }}/{{ proteccio_client_iso }}"
     mode: '644'
-    force: false
+
+- name: Get stats for mount point
+  ansible.builtin.stat:
+    path: /mnt/proteccio_iso
+  register: st
+
+- name: Ensure mount point exists
+  become: true
+  ansible.builtin.file:
+    path: /mnt/proteccio_iso
+    state: directory
+    mode: '755'
+  when: not st.stat.exists
 
 - name: Mount the ISO image
-  ansible.posix.mount:
-    path: /mnt/proteccio_iso
-    src: "{{ working_dir }}/{{ proteccio_client_iso }}"
-    fstype: iso9660
-    state: mounted
-
-- name: Download build tools
   become: true
-  ansible.builtin.dnf:
-    name:
-      - buildah
-      - podman
-    state: present
+  ansible.builtin.command:
+    cmd: "mount -t iso9660 -o loop,ro {{ proteccio_client_iso|quote }} /mnt/proteccio_iso"
+    chdir: "{{ working_dir }}"
+  when: "'/mnt/proteccio_iso' is not mount"
 
 - name: Create and store new images
   ansible.builtin.script: "image_add_proteccio_client.sh"
   environment:
     BARBICAN_SRC_IMAGE_REGISTRY: "{{ barbican_src_image_registry }}"
     BARBICAN_SRC_IMAGE_NAMESPACE: "{{ barbican_src_image_namespace }}"
+    BARBICAN_SRC_API_IMAGE_NAME: "{{ barbican_src_api_image_name }}"
+    BARBICAN_SRC_WORKER_IMAGE_NAME: "{{ barbican_src_worker_image_name }}"
     BARBICAN_SRC_IMAGE_TAG: "{{ barbican_src_image_tag }}"
-    BARBICAN_SRC_API_IMAGE: " {{ barbican_src_api_image }}"
-    BARBICAN_SRC_WORKER_IMAGE: " {{ barbican_src_worker_image }}"
     BARBICAN_DEST_IMAGE_REGISTRY: "{{ barbican_dest_image_registry }}"
     BARBICAN_DEST_IMAGE_NAMESPACE: "{{ barbican_dest_image_namespace }}"
+    BARBICAN_DEST_API_IMAGE_NAME: "{{ barbican_dest_api_image_name }}"
+    BARBICAN_DEST_WORKER_IMAGE_NAME: "{{ barbican_dest_worker_image_name }}"
     BARBICAN_DEST_IMAGE_TAG: "{{ barbican_dest_image_tag }}"
-    BARBICAN_DEST_API_IMAGE: " {{ barbican_dest_api_image }}"
-    BARBICAN_DEST_WORKER_IMAGE: " {{ barbican_dest_worker_image }}"
     VERIFY_TLS: "{{ image_registry_verify_tls }}"
-
-- name: Unmount the ISO image
-  ansible.posix.mount:
-    path: /mnt/proteccio_iso
-    src: "{{ working_dir }}/{{ proteccio_client_iso }}"
-    fstype: iso9660
-    state: unmounted
 
 - name: Perform cleanup tasks
   when:
     - cleanup | bool
   block:
+    - name: Unmount the ISO image
+      become: true
+      ansible.builtin.command:
+        cmd: "umount /mnt/proteccio_iso"
+      when: "'/mnt/proteccio_iso' is mount"
+
+    - name: Remove mount point directory
+      become: true
+      ansible.builtin.file:
+        path: '/mnt/proteccio_iso'
+        state: absent
+
     - name: Remove the working directory
       become: true
       ansible.builtin.file:
         path: "{{ working_dir }}"
         state: absent
-


### PR DESCRIPTION
This patch changes the ISO image mount tasks to use `ansible.builtin.command` instead `ansible.posix.mount` to avoid adding a depenency to the `ansbile.posix` collection.

The names of the API and Worker images can now be provided with role variables.  The default values are the previously hardcoded `openstack-barbican-api` and `openstack-barbican-worker`.