### PR TITLE
Fix certificate get_url task

### DIFF
--- a/tasks/create_secrets.yml
+++ b/tasks/create_secrets.yml
@@ -27,7 +27,7 @@
   block:
     - name: Get certificates and keys
       ansible.builtin.get_url:
-        src: "{{ item }}"
+        url: "{{ item }}"
         dest: "{{ working_dir }}/certs/"
       loop:
         - "{{ proteccio_client_crt_src }}"


### PR DESCRIPTION
This patch fixes a broken `builtin.ansible.get_url` task that is using `src` instead of `url`.